### PR TITLE
Filter autotag workflow to only tag plex updates

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -37,7 +37,7 @@ jobs:
         id: find_renovate_commit
         run: |
           git log -n 20 --pretty=format:'%H|%an|%s' | while IFS='|' read -r commit author subject; do
-            if [[ "$author" == "renovate[bot]" && "${subject,,}" == *"docker tag to "* ]]; then
+            if [[ "$author" == "renovate[bot]" && "${subject,,}" == *"docker tag to "* && "${subject,,}" == *"plex"* ]]; then
               VERSION=$(echo "$subject" | sed -E 's/.*[Dd]ocker tag to (.+)$/\1/')
               echo "new_version=$VERSION" >> $GITHUB_OUTPUT
               echo "commit_hash=$commit" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This should prevent the GitHub workflow from creating a tag based on other dependency updates like https://github.com/spatterIight/ansible-role-plex/releases/tag/v3.14.6-0

cf. https://github.com/mother-of-all-self-hosting/ansible-role-paperless/commit/14c6530c1aec3db5e72cbc0d5d2752698b700c24

After merging, it would be appreciated if https://github.com/spatterIight/ansible-role-plex/releases/tag/v3.14.6-0 is manually removed.